### PR TITLE
Add pyproject.toml for wheel packaging

### DIFF
--- a/file_converters/ifc2json.py
+++ b/file_converters/ifc2json.py
@@ -30,9 +30,9 @@ import argparse
 import json
 import ifcjson
 
-t1_start = perf_counter()
 
-if __name__ == '__main__':
+def main():
+    t1_start = perf_counter()
     parser = argparse.ArgumentParser(
         description='Convert IFC SPF file to IFC.JSON')
     parser.add_argument('-i', type=str, help='input ifc file path')
@@ -95,5 +95,8 @@ if __name__ == '__main__':
             print('Version ' + args.v + ' is not supported')
     else:
         print(str(args.i) + ' is not a valid file')
-t1_stop = perf_counter()
-print("Conversion took ", t1_stop-t1_start, " seconds")
+    print("Conversion took ", perf_counter()-t1_start, " seconds")
+
+
+if __name__ == '__main__':
+    main()

--- a/file_converters/json2ifc.py
+++ b/file_converters/json2ifc.py
@@ -30,9 +30,8 @@ import argparse
 import json
 import ifcjson
 
-start_time = perf_counter()
-
-if __name__ == '__main__':
+def main():
+    start_time = perf_counter()
     parser = argparse.ArgumentParser(
         description='Convert IFC.JSON to SPF')
     parser.add_argument('-i', type=str, help='input json file path')
@@ -52,3 +51,7 @@ if __name__ == '__main__':
         print("Conversion took ", perf_counter()-start_time, " seconds")
     else:
         print(str(args.i) + ' is not a valid file')
+
+
+if __name__ == '__main__':
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,20 @@
+[project]
+name = "ifcjson"
+version = "0.1.0"
+description = "Python converter between IFC SPF and JSON."
+readme = "README.md"
+license = "MIT"
+license-files = ["LICENSE"]
+requires-python = ">=3.10"
+dependencies = [
+    "ifcopenshell",
+]
+
+[project.scripts]
+ifc2json = "ifc2json:main"
+json2ifc = "json2ifc:main"
+
+[tool.setuptools]
+package-dir = {"" = "file_converters"}
+packages = ["ifcjson"]
+py-modules = ["ifc2json", "json2ifc"]


### PR DESCRIPTION
Resolves #5.

We were using `ifcjson` inside https://bonsaibim.org/ and were packing it ourselves. Wanted to upstream `pyproject.toml` to make `ifcjson` installable with simple `pip install git+https://github.com/IFCJSON-Team/IFC2JSON_python`

@janbrouwer can you please take a look?